### PR TITLE
Add metadata with batch inserts in performance-test PROD-5208

### DIFF
--- a/test/insert-performance.js
+++ b/test/insert-performance.js
@@ -31,24 +31,53 @@ else {
     batch = false;
 }
 
+function tonightAtMidnight() {
+    var date = new Date();
+    date.setUTCHours(0);
+    date.setUTCMinutes(0);
+    date.setUTCSeconds(0);
+    date.setUTCMilliseconds(0);
+    return date;
+}
+
+var rowStart = tonightAtMidnight().getTime();
+
 var fields = {
-    "row": "varchar",
-    "col": "int",
-    "val": "int"
+    "name": "varchar",
+    "tag1": "varchar",
+    "tag2": "varchar",
+    "tag3": "varchar",
+    "tag4": "varchar",
+    "value": "double",
+    "time": "int"
 };
 
-var key = "row, col";
+var key = _.keys(fields).filter(function(k) {
+    return k !== 'value';
+}).join(', ');
+
+var tagValues = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
+
+function randomTag() {
+    var index = Math.floor(Math.random() * tagValues.length);
+    return string(tagValues[index]);
+}
 
 function string(x) {
     return '\'' + x.toString() + '\'';
 }
+
 var col = 0;
+
 function generate() {
-    var row = col % 10;
     var ret = {
-        row: string(row),
-        col: col,
-        val: Math.floor(Math.random() * 100)
+        name: randomTag(),
+        tag1: randomTag(),
+        tag2: randomTag(),
+        tag3: randomTag(),
+        tag4: randomTag(),
+        value: Math.random(),
+        time: col,
     };
     col++;
     return ret;
@@ -75,7 +104,7 @@ client.connect('127.0.0.1')
 .then(function() {
     start = new Date();
     if (batch) {
-        return client.insertRowsPreparedBatch(table, data, batch, concurrent);
+        return client.insertRowsPreparedBatch(table, data, batch, concurrent, true);
     } else if (prepared) {
         return client.insertRowsPrepared(table, data, concurrent);
     } else {


### PR DESCRIPTION
So I made this index called 'metadata', and it has a document type for each metric name. Each metric name/document type has one document in it, which is a big object that looks like 

```
{
    "tagName:tagValue": 1
}
```

for all tag names and tag values. That seemed like the most efficient way to encode the tag information. We modify this object with bulk update requests, using the doc_as_upsert and detect_noop flags (http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-update.html). I ran some batch import requests with 10000 semi-realistic points consisting of a name, timestamp and four tags with 10 possible values. Here's how it went:

```
$ node test/insert-performance.js 10000 1000 batch 1000
done inserting  10000  meta-points, took 7.296 seconds
$ node test/insert-performance.js 10000 1000 batch 1000
done inserting  10000  meta-points, took 4.248 seconds
$ node test/insert-performance.js 10000 1000 batch 1000
done inserting  10000  meta-points, took 2.294 seconds
$ node test/insert-performance.js 10000 1000 batch 1000
done inserting  10000  meta-points, took 2.28 seconds
$ node test/insert-performance.js 10000 1000 batch 1000
done inserting  10000  meta-points, took 2.187 seconds
$ node test/insert-performance.js 10000 1000 batch 1000
done inserting  10000  meta-points, took 2.424 seconds
```

So the first one was really expensive because it had to do a lot of document creation and reindexing, but subsequent runs got faster until we were getting ~4500 meta-points per second. You can't do many more than 10000 meta-points in one request before your request starts getting intractably large. The Cassandra points always went in a lot faster, of course. 
So the performance isn't just awful, but I don't think it's quite good enough.

@demmer @aswan 

P.S. in the absence of metadata, the semi-realistic metrics go into Cassie at about 70k/second.
