### PR TITLE
persistent-string: add a simple helper class for static strings

### DIFF
--- a/src/batch.cc
+++ b/src/batch.cc
@@ -2,6 +2,7 @@
 
 #include "batch.h"
 #include "client.h"
+#include "persistent-string.h"
 #include "prepared-query.h"
 #include "query.h"
 #include "type-mapper.h"
@@ -78,7 +79,8 @@ Batch::~Batch()
 void
 Batch::set_client(const Local<Object>& client)
 {
-    handle_->Set(NanNew("client"), client);
+    static PersistentString client_str("client");
+    handle_->Set(client_str, client);
 
     Client* c = node::ObjectWrap::Unwrap<Client>(client);
     session_ = c->get_session();
@@ -111,7 +113,7 @@ WRAPPED_METHOD(Batch, AddPrepared)
     Local<Array> hints;
 
     if (args.Length() > 2) {
-        Local<String> hints_str = NanNew("hints");
+        static PersistentString hints_str("hints");
         Local<Object> options = args[2].As<Object>();
         if (options->Has(hints_str)) {
             hints = options->Get(hints_str).As<Array>();

--- a/src/client.cc
+++ b/src/client.cc
@@ -1,6 +1,7 @@
 
 #include "client.h"
 #include "batch.h"
+#include "persistent-string.h"
 #include "prepared-query.h"
 #include "query.h"
 
@@ -76,8 +77,8 @@ WRAPPED_METHOD(Client, Connect) {
     }
 
     Local<Object> options = args[0].As<Object>();
-    Local<String> address_str = NanNew("address");
-    Local<String> port_str = NanNew("port");
+    static PersistentString address_str("address");
+    static PersistentString port_str("port");
 
     int port;
 

--- a/src/persistent-string.h
+++ b/src/persistent-string.h
@@ -1,0 +1,35 @@
+#ifndef __CASS_DRIVER_PERSISTENT_STRING_H__
+#define __CASS_DRIVER_PERSISTENT_STRING_H__
+
+#include "nan.h"
+
+// Simple helper class
+class PersistentString {
+public:
+    PersistentString(const char* str) : string_(str) {
+    }
+
+    // Return a local handle to the persistent string
+    v8::Local<v8::String> handle() {
+        if (handle_.IsEmpty()) {
+            NanAssignPersistent(handle_, NanNew<String>(string_.c_str()));
+        }
+        return NanNew<String>(handle_);
+    }
+
+    // Define the casting operator to a local handle so that a persistent string
+    // can be passed as a parameter to Object::Set()
+    operator const v8::Handle<v8::Value>() {
+        return handle();
+    }
+
+    operator const v8::Handle<v8::String>() {
+        return handle();
+    }
+
+private:
+    v8::Persistent<v8::String> handle_;
+    std::string string_;
+};
+
+#endif

--- a/src/prepared-query.cc
+++ b/src/prepared-query.cc
@@ -2,6 +2,7 @@
 
 #include "prepared-query.h"
 #include "client.h"
+#include "persistent-string.h"
 #include "query.h"
 #include "type-mapper.h"
 
@@ -60,7 +61,8 @@ PreparedQuery::~PreparedQuery()
 void
 PreparedQuery::set_client(Local<Object>& client)
 {
-    handle_->Set(NanNew("client"), client);
+    static PersistentString client_str("client");
+    handle_->Set(client_str, client);
 
     Client* c = node::ObjectWrap::Unwrap<Client>(client);
     session_ = c->get_session();
@@ -136,7 +138,8 @@ WRAPPED_METHOD(PreparedQuery, GetQuery)
 
     Query* query = node::ObjectWrap::Unwrap<Query>(val->ToObject());
 
-    query->set_client(handle_->Get(NanNew("client")).As<Object>());
+    static PersistentString client_str("client");
+    query->set_client(handle_->Get(client_str).As<Object>());
 
     query->set_prepared_statement(prepare_statement());
 

--- a/src/result.cc
+++ b/src/result.cc
@@ -1,6 +1,7 @@
 #include <cassandra.h>
 
 #include "result.h"
+#include "persistent-string.h"
 #include "type-mapper.h"
 
 Result::Result()
@@ -41,11 +42,13 @@ Result::do_callback(CassFuture* future, NanCallback* callback)
 
     Local<Array> res = NanNew<Array>();
 
+    static PersistentString more_str("more");
     cass_bool_t more = cass_result_has_more_pages(result_);
-    res->Set(NanNew("more"), more ? NanTrue() : NanFalse() );
+    res->Set(more_str, more ? NanTrue() : NanFalse() );
 
+    static PersistentString rows_str("rows");
     Local<Array> data = NanNew<Array>();
-    res->Set(NanNew("rows"), data);
+    res->Set(rows_str, data);
     CassIterator* iterator = cass_iterator_from_result(result_);
 
     // Stash the column info for the first batch of results.


### PR DESCRIPTION
Instead of calling `NanNew("...")` each time a constant string is needed,
this class wraps a Persistent<String> handle and supplies a casting
operator, so the following will only allocate the string once:

   `static PersistentString str("...");`

Then it can be used as a Local handle wherever needed.
