### PR TITLE
Make res an object

### DIFF
--- a/src/result.cc
+++ b/src/result.cc
@@ -40,7 +40,7 @@ Result::do_callback(CassFuture* future, NanCallback* callback)
 
     result_ = cass_future_get_result(future);
 
-    Local<Array> res = NanNew<Array>();
+    Local<Object> res = NanNew<Object>();
 
     static PersistentString more_str("more");
     cass_bool_t more = cass_result_has_more_pages(result_);


### PR DESCRIPTION
We send back this res thing with properties "rows" and "more" and it should definitely be an object and not an array like it is.
@demmer 
