### PR TITLE
add support for timestamps

### DIFF
--- a/src/type-mapper.cc
+++ b/src/type-mapper.cc
@@ -92,6 +92,11 @@ TypeMapper::bind_statement_param(CassStatement* statement, u_int32_t i,
         cass_statement_bind_int32(statement, i, intValue);
         return true;
     }
+    case CASS_VALUE_TYPE_TIMESTAMP: {
+        cass_int64_t intValue = value->ToNumber()->IntegerValue();
+        cass_statement_bind_int64(statement, i, intValue);
+        return true;
+    }
     case CASS_VALUE_TYPE_BOOLEAN: {
         cass_bool_t booleanValue = (value->BooleanValue() ? cass_true : cass_false);
         cass_statement_bind_bool(statement, i, booleanValue);
@@ -120,7 +125,6 @@ TypeMapper::bind_statement_param(CassStatement* statement, u_int32_t i,
     case CASS_VALUE_TYPE_DECIMAL:
     case CASS_VALUE_TYPE_FLOAT:
     case CASS_VALUE_TYPE_TEXT:
-    case CASS_VALUE_TYPE_TIMESTAMP:
     case CASS_VALUE_TYPE_UUID:
     case CASS_VALUE_TYPE_VARINT:
     case CASS_VALUE_TYPE_TIMEUUID:
@@ -149,6 +153,11 @@ TypeMapper::append_collection(CassCollection* collection, const Local<Value>& va
         cass_collection_append_int32(collection, intValue);
         return true;
     }
+    case CASS_VALUE_TYPE_TIMESTAMP: {
+        cass_int64_t intValue = value->ToNumber()->IntegerValue();
+        cass_collection_append_int64(collection, intValue);
+        return true;
+    }
     case CASS_VALUE_TYPE_DOUBLE: {
         cass_double_t doubleValue = value->ToNumber()->NumberValue();
         cass_collection_append_double(collection, doubleValue);
@@ -173,7 +182,6 @@ TypeMapper::append_collection(CassCollection* collection, const Local<Value>& va
     case CASS_VALUE_TYPE_DECIMAL:
     case CASS_VALUE_TYPE_FLOAT:
     case CASS_VALUE_TYPE_TEXT:
-    case CASS_VALUE_TYPE_TIMESTAMP:
     case CASS_VALUE_TYPE_UUID:
     case CASS_VALUE_TYPE_VARINT:
     case CASS_VALUE_TYPE_TIMEUUID:
@@ -213,6 +221,14 @@ TypeMapper::v8_from_cassandra(v8::Local<v8::Value>* result, CassValueType type,
             return false;
         }
         *result = NanNew<Number>(intValue);
+        return true;
+    }
+    case CASS_VALUE_TYPE_TIMESTAMP: {
+        cass_int64_t intValue;
+        if (cass_value_get_int64(value, &intValue) != CASS_OK) {
+            return false;
+        }
+        *result = NanNew<Number>((double)intValue);
         return true;
     }
     case CASS_VALUE_TYPE_DOUBLE: {
@@ -257,7 +273,6 @@ TypeMapper::v8_from_cassandra(v8::Local<v8::Value>* result, CassValueType type,
     case CASS_VALUE_TYPE_DECIMAL:
     case CASS_VALUE_TYPE_FLOAT:
     case CASS_VALUE_TYPE_TEXT:
-    case CASS_VALUE_TYPE_TIMESTAMP:
     case CASS_VALUE_TYPE_UUID:
     case CASS_VALUE_TYPE_VARINT:
     case CASS_VALUE_TYPE_TIMEUUID:

--- a/test/hints.spec.js
+++ b/test/hints.spec.js
@@ -9,6 +9,41 @@ var setup_environment = require('./test-utils').setup_environment;
 
 var client;
 
+var types = [
+    {
+        type: 'int',
+        value: 1,
+        code: types.CASS_VALUE_TYPE_INT
+    },
+    {
+        type: 'double',
+        value: 1.1,
+        code: types.CASS_VALUE_TYPE_DOUBLE
+    },
+    {
+        type: 'timestamp',
+        value: 1423515666128,
+        code: types.CASS_VALUE_TYPE_TIMESTAMP
+    },
+    {
+        type: 'boolean',
+        value: false,
+        code: types.CASS_VALUE_TYPE_BOOLEAN
+    },
+    {
+        type: 'varchar',
+        value: 'hello momma',
+        code: types.CASS_VALUE_TYPE_VARCHAR
+    },
+    {
+        type: 'blob',
+        value: new Buffer([1, 2, 3]),
+        code: types.CASS_VALUE_TYPE_BLOB
+    }
+];
+
+// XXX should test all of the above inside a map.
+
 describe('hints', function() {
     before(function() {
         client = new TestClient();
@@ -16,21 +51,40 @@ describe('hints', function() {
     });
 
     _.each(['insertRows', 'insertRowsPrepared', 'insertRowsPreparedBatch'], function(method, index) {
-        it(method + ' storing ints in a table whose value type is double', function() {
-            var table = 'hint_test' + index;
-            var data = [{key: 1, value: 1}];
-            return client.createTable(table, {key: 'int', value: 'double'}, 'key')
-            .then(function() {
-                return client[method](table, data, {hints: {key: types.CASS_VALUE_TYPE_INT, value: types.CASS_VALUE_TYPE_DOUBLE}, batch_size: 1});
-            })
-            .then(function() {
-                return client.execute('select * from ' + table + ' where key=?;', [data[0].key]);
-            })
-            .then(function(results) {
-                var res = results.rows;
-                expect(res).deep.equal(data);
-            })
-            .finally(function(err) {
+        describe(method, function() {
+            var table, data;
+            it('creates the table', function() {
+                table = 'hint_test' + index;
+
+                var fields = {key: 'varchar'};
+                _.each(types, function(t) {
+                    fields[t.type + '_field'] = t.type;
+                });
+
+                return client.createTable(table, fields, 'key');
+            });
+
+            it('inserts some data', function() {
+                var hints = {};
+                data = {key: 'test_key'};
+
+                _.each(types, function(t) {
+                    hints[t.type + '_field'] = t.code;
+                    data[t.type + '_field'] = t.value;
+                });
+
+                return client[method](table, [data], {hints: hints, batch_size: 1});
+            });
+
+            it('queries the data', function() {
+                return client.execute('select * from ' + table + ' where key=?;', ['test_key'])
+                .then(function(results) {
+                    var res = results.rows;
+                    expect(res[0]).deep.equal(data);
+                });
+            });
+
+            after(function() {
                 return client.execute('drop table ' + table + ';');
             });
         });

--- a/test/timestamp.spec.js
+++ b/test/timestamp.spec.js
@@ -1,0 +1,74 @@
+var TestClient = require('./test-client');
+var Promise = require('bluebird');
+var expect = require('chai').expect;
+var ks = 'paging_test';
+var table = 'test';
+var _ = require('underscore');
+var util = require('util');
+var test_utils = require('./test-utils');
+
+var fields = {
+    'row': 'varchar',
+    'col': 'int',
+    'val': 'int'
+};
+
+var key = 'row, col';
+var client;
+
+describe('timestamp support', function() {
+    before(function() {
+        client = new TestClient();
+        return test_utils.setup_environment(client)
+        .then(function() {
+            return client.createTable(table, fields, key);
+        });
+    });
+
+    _.each(['insertRows', 'insertRowsPrepared', 'insertRowsPreparedBatch'], function(method, index) {
+        var data = test_utils.generate(100);
+        describe(method, function() {
+            it('inserts data with timestamp', function() {
+                var now = new Date().getTime();
+                return client[method](table, data, {timestamp: now, ttl: 1});
+            });
+
+            it('retrieves all the data when immediately querying', function() {
+                var rows = _.times(10, function (i) { return 'row-' + i; });
+
+                var cql = util.format('SELECT * FROM %s', table);
+                return client.execute(cql)
+                    .then(function(results) {
+                        expect(results.rows.length).equal(data.length);
+
+                        var cols = _.pluck(results.rows, 'col');
+
+                        cols.sort(function(a,b) { return a - b; });
+
+                        for (i = 0; i < cols.length; ++i) {
+                            expect(cols[i]).equal(i);
+                        }
+                    });
+            });
+
+            it('waits for a few seconds', function() {
+                this.timeout(5000);
+                return Promise.delay(2000);
+            });
+
+            it('queries again and should get no data', function() {
+                var rows = _.times(10, function (i) { return 'row-' + i; });
+
+                var cql = util.format('SELECT * FROM %s', table);
+                return client.execute(cql)
+                    .then(function(results) {
+                        expect(results.rows.length).equal(0);
+                    });
+            });
+        });
+    });
+
+    after(function() {
+        return client.cleanup();
+    });
+});


### PR DESCRIPTION
Updates the type mapper to include support for cassandra TIMESTAMP types
and adds some hooks to the test client to set the timestamp and ttl on
insert.
