### PR TITLE
free the session if connect fails

### DIFF
--- a/src/client.cc
+++ b/src/client.cc
@@ -95,6 +95,7 @@ WRAPPED_METHOD(Client, Connect) {
     NanCallback* callback = new NanCallback(args[1].As<Function>());
 
     session_ = cass_session_new();
+
     CassFuture* future = cass_session_connect(session_, cluster_);
     async_.schedule(on_connected, future, this, callback);
 
@@ -120,10 +121,14 @@ Client::connected(CassFuture* future, NanCallback* callback)
         CassString error = cass_future_error_message(future);
         std::string error_str = std::string(error.data, error.length);
 
+        cass_session_free(session_);
+        session_ = NULL;
+
         Handle<Value> argv[] = {
             NanError(error_str.c_str())
         };
         callback->Call(1, argv);
+
     } else {
         Handle<Value> argv[] = {
             NanNull(),

--- a/test/connect-errors.spec.js
+++ b/test/connect-errors.spec.js
@@ -1,0 +1,20 @@
+var TestClient = require('./test-client');
+var _ = require('underscore');
+var Promise = require('bluebird');
+var expect = require('chai').expect;
+
+describe('connection error handling', function() {
+    it('fails to connect repeatedly to a non-listening address', function() {
+        var client = new TestClient();
+        this.timeout(30000);
+        return Promise.each(_.range(10001, 10105), function(port) {
+            return client.connect({address: '127.0.0.1', port: port})
+            .then(function() {
+                throw new Error('unexpected success');
+            })
+            .catch(function(err) {
+                expect(err.message).equal('No hosts available');
+            });
+        });
+    });
+});


### PR DESCRIPTION
If connect fails we don't properly free the session, and it looks like if the same client is used to connect again then the driver gets unhappy and dumps core.
