### PR TITLE
batch: free the statement after adding to batch

### DIFF
--- a/src/batch.cc
+++ b/src/batch.cc
@@ -130,6 +130,7 @@ WRAPPED_METHOD(Batch, AddPrepared)
     }
 
     cass_batch_add_statement(batch_, statement);
+    cass_statement_free(statement);
 
     NanReturnUndefined();
 }


### PR DESCRIPTION
This fixes an egregious memory leak that occurred every time a batch is used with a prepared query.
