### PR TITLE
Fix for linux compile warnings

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,7 @@
 {
+  "target_defaults": {
+    "cflags": [ "-Wno-unused-local-typedefs" ]
+  },
   "targets": [
     {
       "target_name": "cassandra-native-driver",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cassandra-native-driver",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "node.js addon for the the C++ native cassandra driver",
   "main": "index.js",
   "repository": "https://github.com/jut-io/node-cassandra-native-driver",

--- a/src/type-mapper.cc
+++ b/src/type-mapper.cc
@@ -73,8 +73,8 @@ TypeMapper::bind_statement_param(CassStatement* statement, u_int32_t i,
         Local<Array> array = val.As<Array>();
         size_t length = array->Length();
         CassCollection* list = cass_collection_new(CASS_COLLECTION_TYPE_LIST, array->Length());
-        for (size_t i = 0; i < length; ++i) {
-            Local<Value> val = array->Get(i);
+        for (size_t j = 0; j < length; ++j) {
+            Local<Value> val = array->Get(j);
             append_collection(list, val);
         }
         cass_statement_bind_collection(statement, i, list);
@@ -106,8 +106,8 @@ TypeMapper::bind_statement_param(CassStatement* statement, u_int32_t i,
         Local<Object> obj = value->ToObject();
         Local<Array> keys = obj->GetOwnPropertyNames();
         CassCollection* cassObj = cass_collection_new(CASS_COLLECTION_TYPE_MAP, keys->Length());
-        for (size_t i = 0; i < keys->Length(); i++) {
-            Local<Value> key = keys->Get(i);
+        for (size_t j = 0; j < keys->Length(); j++) {
+            Local<Value> key = keys->Get(j);
             Local<Value> val = obj->Get(key);
             if (!append_collection(cassObj, key) || !append_collection(cassObj, val)) {
                 return false;
@@ -130,6 +130,7 @@ TypeMapper::bind_statement_param(CassStatement* statement, u_int32_t i,
     case CASS_VALUE_TYPE_TIMEUUID:
     case CASS_VALUE_TYPE_INET:
     case CASS_VALUE_TYPE_SET:
+    default:
         return false;
     }
 }


### PR DESCRIPTION
(1) added "no-unused-local-typedefs" to avoid numerous warnings.

(2) replaced ambiguous use of variable "i" with "j". The "i" gets passed in (fixes "matches this ‘i’ under ISO standard rules", "matches this ‘i’ under old rules", and "name lookup of ‘i’ changed" warnings ).

(3) add a default case for the switch statement (for "control reaches end of non-void function" warning).

I see a number of `test/*.js` files. Do they automatically get run by bamboo? If not how do I run them?  

@davidvgalbraith @demmer 
