### PR TITLE
Use UTF8 instead of ASCII in type-mapper PROD-6983

### DIFF
--- a/src/type-mapper.cc
+++ b/src/type-mapper.cc
@@ -82,8 +82,8 @@ TypeMapper::bind_statement_param(CassStatement* statement, u_int32_t i,
         return true;
     }
     case CASS_VALUE_TYPE_VARCHAR: {
-        String::AsciiValue ascii_str(value->ToString());
-        CassString str = cass_string_init(*ascii_str);
+        String::Utf8Value utf8_str(value->ToString());
+        CassString str = cass_string_init(*utf8_str);
         cass_statement_bind_string(statement, i, str);
         return true;
     }
@@ -170,8 +170,8 @@ TypeMapper::append_collection(CassCollection* collection, const Local<Value>& va
         return true;
     }
     case CASS_VALUE_TYPE_VARCHAR: {
-        String::AsciiValue ascii_str(value->ToString());
-        CassString str = cass_string_init(*ascii_str);
+        String::Utf8Value utf8_str(value->ToString());
+        CassString str = cass_string_init(*utf8_str);
         cass_collection_append_string(collection, str);
         return true;
     }

--- a/test/types.spec.js
+++ b/test/types.spec.js
@@ -6,7 +6,7 @@ var test_utils = require('./test-utils');
 
 var client;
 var tests = {
-    varchar: ['foo', 'bar'],
+    varchar: ['foo', String.fromCharCode(160)],
     int: [123, 456],
     boolean: [true, false],
     double: [1.23, 4.56],


### PR DESCRIPTION
The type-mapper only understands ASCII, even though Cassie has no trouble with UTF8. Let's use UTF8 in the type mapper so we can store all kinds of weird strings if we want.
@demmer @aswan 
