### PR TITLE
Add driver support for counters

### DIFF
--- a/src/type-mapper.cc
+++ b/src/type-mapper.cc
@@ -92,6 +92,7 @@ TypeMapper::bind_statement_param(CassStatement* statement, u_int32_t i,
         cass_statement_bind_int32(statement, i, intValue);
         return true;
     }
+    case CASS_VALUE_TYPE_COUNTER:
     case CASS_VALUE_TYPE_TIMESTAMP: {
         cass_int64_t intValue = value->ToNumber()->IntegerValue();
         cass_statement_bind_int64(statement, i, intValue);
@@ -121,7 +122,6 @@ TypeMapper::bind_statement_param(CassStatement* statement, u_int32_t i,
     case CASS_VALUE_TYPE_CUSTOM:
     case CASS_VALUE_TYPE_ASCII:
     case CASS_VALUE_TYPE_BIGINT:
-    case CASS_VALUE_TYPE_COUNTER:
     case CASS_VALUE_TYPE_DECIMAL:
     case CASS_VALUE_TYPE_FLOAT:
     case CASS_VALUE_TYPE_TEXT:
@@ -154,6 +154,7 @@ TypeMapper::append_collection(CassCollection* collection, const Local<Value>& va
         cass_collection_append_int32(collection, intValue);
         return true;
     }
+    case CASS_VALUE_TYPE_COUNTER:
     case CASS_VALUE_TYPE_TIMESTAMP: {
         cass_int64_t intValue = value->ToNumber()->IntegerValue();
         cass_collection_append_int64(collection, intValue);
@@ -179,7 +180,6 @@ TypeMapper::append_collection(CassCollection* collection, const Local<Value>& va
     case CASS_VALUE_TYPE_CUSTOM:
     case CASS_VALUE_TYPE_ASCII:
     case CASS_VALUE_TYPE_BIGINT:
-    case CASS_VALUE_TYPE_COUNTER:
     case CASS_VALUE_TYPE_DECIMAL:
     case CASS_VALUE_TYPE_FLOAT:
     case CASS_VALUE_TYPE_TEXT:
@@ -224,6 +224,7 @@ TypeMapper::v8_from_cassandra(v8::Local<v8::Value>* result, CassValueType type,
         *result = NanNew<Number>(intValue);
         return true;
     }
+    case CASS_VALUE_TYPE_COUNTER:
     case CASS_VALUE_TYPE_TIMESTAMP: {
         cass_int64_t intValue;
         if (cass_value_get_int64(value, &intValue) != CASS_OK) {
@@ -270,7 +271,6 @@ TypeMapper::v8_from_cassandra(v8::Local<v8::Value>* result, CassValueType type,
     case CASS_VALUE_TYPE_CUSTOM:
     case CASS_VALUE_TYPE_ASCII:
     case CASS_VALUE_TYPE_BIGINT:
-    case CASS_VALUE_TYPE_COUNTER:
     case CASS_VALUE_TYPE_DECIMAL:
     case CASS_VALUE_TYPE_FLOAT:
     case CASS_VALUE_TYPE_TEXT:

--- a/test/counters.spec.js
+++ b/test/counters.spec.js
@@ -1,0 +1,79 @@
+var TestClient = require('./test-client');
+var Promise = require('bluebird');
+var expect = require('chai').expect;
+var table = 'test';
+var _ = require('underscore');
+var util = require('util');
+var test_utils = require('./test-utils');
+
+var fields = {
+    'day': 'int',
+    'usage': 'counter'
+};
+
+var NUM_POINTS = 50;
+var msInDay = 1000 * 60 * 60 * 24;
+var data = _.times(NUM_POINTS, function(n) {
+    var d = new Date();
+    d.setUTCDate(d.getUTCDate() - NUM_POINTS + n);
+    return {
+        day: Math.floor(d.getTime() / msInDay),
+        usage: Math.pow(2, n)
+    };
+});
+
+var key = 'day';
+var client;
+
+describe('counter support', function() {
+    before(function() {
+        client = new TestClient();
+        return test_utils.setup_environment(client)
+        .then(function() {
+            return client.createTable(table, fields, key);
+        });
+    });
+
+    it('inserts data with a counter', function() {
+        var cqlBase = 'UPDATE %s SET usage = usage + %d WHERE day = %s';
+        return Promise.each(data, function(pt) {
+            var cql = util.format(cqlBase, table, pt.usage, pt.day);
+            return client.execute(cql, [], {});
+        });
+    });
+
+    it('retrieves all the data', function() {
+        var cql = util.format('SELECT * FROM %s', table);
+        return client.execute(cql)
+            .then(function(results) {
+                var received = _.sortBy(results.rows, 'day');
+                expect(received).deep.equal(data);
+            });
+    });
+
+    it('updates existing counters', function() {
+        var cqlBase = 'UPDATE %s SET usage = usage + %d WHERE day = %s';
+        return Promise.each(data, function(pt) {
+            var cql = util.format(cqlBase, table, 5, pt.day);
+            return client.execute(cql, [], {});
+        });
+    });
+
+    it('retrieves the updated data', function() {
+        var cql = util.format('SELECT * FROM %s', table);
+        return client.execute(cql)
+            .then(function(results) {
+                var received = _.sortBy(results.rows, 'day');
+                var expected = data.map(function(pt) {
+                    var clone = _.clone(pt);
+                    clone.usage += 5;
+                    return clone;
+                });
+                expect(received).deep.equal(expected);
+            });
+    });
+
+    after(function() {
+        return client.cleanup();
+    });
+});


### PR DESCRIPTION
cassandra.h says that cass_statement_bind_int64

```
 * Binds a "bigint", "counter" or "timestamp" to a query or bound statement
 * at the specified index.
```

so we can just piggyback on the already-existing timestamp-handling code. The syntax is a little wonky (http://docs.datastax.com/en/cql/3.0/cql/cql_using/use_counter_t.html, you insert by updating), but it seems to work.
@aswan @demmer 
