### PR TITLE
add stats and feature to make async-future yield if slow

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -169,4 +169,8 @@ Client.prototype.new_batch = function(type) {
     return this.client.new_batch(type);
 };
 
+Client.prototype.metrics = function(reset) {
+    return this.client.metrics(reset);
+};
+
 module.exports = Client;

--- a/src/async-future.cc
+++ b/src/async-future.cc
@@ -75,13 +75,22 @@ void
 AsyncFuture::async_ready()
 {
     uv_mutex_lock(&lock_);
-    if (queue_.empty()) {
-        uv_mutex_unlock(&lock_);
-        return;
+
+    // Keep track of whether there were leftover items in the ready_queue_ due
+    // to the result_loop_elapsed_max limit having been triggered previously. If
+    // true, then once the ready_queue is drained, the async needs to be kicked
+    // to handle any events that may be in the queue_.
+    bool ready_queue_was_empty = ready_queue_.empty();
+
+    if (ready_queue_was_empty) {
+        if (queue_.empty()) {
+            uv_mutex_unlock(&lock_);
+            return;
+        }
+
+        std::swap(queue_, ready_queue_);
     }
 
-    std::queue<Pending*> ready_queue;
-    std::swap(queue_, ready_queue);
     uv_mutex_unlock(&lock_);
 
     uint32_t count = 0;
@@ -89,12 +98,28 @@ AsyncFuture::async_ready()
     uint32_t elapsed;
 
     ::gettimeofday(&start, 0);
-    while (! ready_queue.empty()) {
-        Pending* pending = ready_queue.front();
-        ready_queue.pop();
+    while (! ready_queue_.empty()) {
+        Pending* pending = ready_queue_.front();
+        ready_queue_.pop();
         pending->callback_(pending->future_, pending->client_, pending->data_);
         delete pending;
         count++;
+
+        if (result_loop_elapsed_max_ != 0) {
+            ::gettimeofday(&end, 0);
+            elapsed = timeval_diff_us(start, end);
+            if (elapsed > result_loop_elapsed_max_ * 1000) {
+                metrics_->response_queue_elapsed_limit_count_++;
+                break;
+            }
+        }
+    }
+
+    // If there were leftover items in the ready queue when this wakeup
+    // occurred, or if there are any leftover items from this iteration, then
+    // make sure to schedule another wakeup.
+    if (! ready_queue_was_empty || !ready_queue_.empty()) {
+        uv_async_send(async_);
     }
 
     ::gettimeofday(&end, 0);

--- a/src/async-future.h
+++ b/src/async-future.h
@@ -17,6 +17,10 @@ public:
     // Schedule a callback when the given future is ready.
     void schedule(callback_t callback, CassFuture* future, void* client, void* data);
 
+    // Configure the maximum time (in ms) to spend draining the result queue
+    void set_result_loop_elapsed_max(uint32_t max) {
+        result_loop_elapsed_max_ = max;
+    }
 private:
     // Wrapper for a pending future operation
     struct Pending {
@@ -34,6 +38,8 @@ private:
     uv_mutex_t lock_;
     uv_async_t* async_;
     std::queue<Pending*> queue_;
+    std::queue<Pending*> ready_queue_;
+    uint32_t result_loop_elapsed_max_;
 
     // Notification on the worker thread when a future is ready
     static void on_future_ready(CassFuture* future, void* data);

--- a/src/async-future.h
+++ b/src/async-future.h
@@ -2,11 +2,13 @@
 #include <uv.h>
 #include <queue>
 
+class Metrics;
+
 // Helper class to schedule a callback on the v8 main thread to handle a
 // CassFuture.
 class AsyncFuture {
 public:
-    AsyncFuture();
+    AsyncFuture(Metrics* metrics);
     ~AsyncFuture();
 
     // Callback function signature
@@ -28,6 +30,7 @@ private:
         void* data_;
     };
 
+    Metrics* metrics_;
     uv_mutex_t lock_;
     uv_async_t* async_;
     std::queue<Pending*> queue_;

--- a/src/batch.h
+++ b/src/batch.h
@@ -11,6 +11,7 @@ using namespace v8;
 
 class AsyncFuture;
 class Client;
+class Metrics;
 
 // Wrapper for a batched query
 class Batch: public node::ObjectWrap {
@@ -46,6 +47,7 @@ private:
 
     CassSession* session_;
     CassBatch* batch_;
+    Metrics* metrics_;
 
     bool fetching_;
 

--- a/src/client.cc
+++ b/src/client.cc
@@ -77,6 +77,7 @@ void
 Client::configure(v8::Local<v8::Object> opts)
 {
     static PersistentString keepalive_str("tcp_keepalive_delay");
+    static PersistentString result_loop_elapsed_max_str("result_loop_elapsed_max");
     const Local<Array> props = opts->GetPropertyNames();
     const uint32_t length = props->Length();
     for (uint32_t i = 0; i < length; ++i)
@@ -122,6 +123,10 @@ Client::configure(v8::Local<v8::Object> opts)
             } else {
                 cass_cluster_set_tcp_nodelay(cluster_, cass_true);
             }
+        }
+
+        if (key->Equals(result_loop_elapsed_max_str)) {
+            async_.set_result_loop_elapsed_max(value);
         }
     }
 }

--- a/src/client.cc
+++ b/src/client.cc
@@ -10,7 +10,10 @@ using namespace v8;
 
 Persistent<Function> Client::constructor;
 
-Client::Client() {
+Client::Client()
+    : metrics_(),
+      async_(&metrics_)
+{
     cluster_ = cass_cluster_new();
     session_ = NULL;
 }
@@ -36,6 +39,7 @@ void Client::Init() {
     NODE_SET_PROTOTYPE_METHOD(tpl, "new_query", WRAPPED_METHOD_NAME(NewQuery));
     NODE_SET_PROTOTYPE_METHOD(tpl, "new_prepared_query", WRAPPED_METHOD_NAME(NewPreparedQuery));
     NODE_SET_PROTOTYPE_METHOD(tpl, "new_batch", WRAPPED_METHOD_NAME(NewBatch));
+    NODE_SET_PROTOTYPE_METHOD(tpl, "metrics", WRAPPED_METHOD_NAME(Metrics));
 
     NanAssignPersistent(constructor, tpl->GetFunction());
 }
@@ -237,4 +241,19 @@ WRAPPED_METHOD(Client, NewBatch) {
     }
 
     NanReturnValue(val);
+}
+
+WRAPPED_METHOD(Client, Metrics) {
+    NanScope();
+
+    bool reset = false;
+    if (args.Length() == 1) {
+        reset = args[0]->IsTrue();
+    }
+
+    Local<Object> metrics = metrics_.get();
+    if (reset) {
+        metrics_.clear();
+    }
+    NanReturnValue(metrics);
 }

--- a/src/client.h
+++ b/src/client.h
@@ -7,6 +7,7 @@
 #include "wrapped-method.h"
 #include "buffer-pool.h"
 #include "async-future.h"
+#include "metrics.h"
 
 class Client : public node::ObjectWrap {
 public:
@@ -15,10 +16,12 @@ public:
 
     CassSession* get_session() { return session_; }
     AsyncFuture* get_async() { return &async_; }
+    Metrics* metrics() { return &metrics_; }
 private:
     CassCluster* cluster_;
     CassSession* session_;
 
+    Metrics metrics_;
     AsyncFuture async_;
 
     static void on_connected(CassFuture* future, void* client, void* data);
@@ -33,6 +36,7 @@ private:
     WRAPPED_METHOD_DECL(NewQuery);
     WRAPPED_METHOD_DECL(NewPreparedQuery);
     WRAPPED_METHOD_DECL(NewBatch);
+    WRAPPED_METHOD_DECL(Metrics);
 
     void configure(v8::Local<v8::Object> opts);
 

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -25,6 +25,7 @@ public:
     uint32_t pending_request_count_max_;
     uint32_t response_queue_drain_count_max_;
     uint32_t response_queue_drain_time_max_;
+    uint32_t response_queue_elapsed_limit_count_;
 };
 
 inline void
@@ -35,6 +36,7 @@ Metrics::clear()
     pending_request_count_max_ = 0;
     response_queue_drain_count_max_ = 0;
     response_queue_drain_time_max_ = 0;
+    response_queue_elapsed_limit_count_ = 0;
 }
 
 inline void
@@ -69,6 +71,7 @@ Metrics::get()
     GET(pending_request_count_max);
     GET(response_queue_drain_count_max);
     GET(response_queue_drain_time_max);
+    GET(response_queue_elapsed_limit_count);
 
 #undef GET
 

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -1,0 +1,78 @@
+#ifndef __CASS_DRIVER_METRICS_H__
+#define __CASS_DRIVER_METRICS_H__
+
+#include "nan.h"
+#include "persistent-string.h"
+
+class Metrics {
+public:
+    Metrics() { clear(); }
+
+    // Reset (zero-out) the current metrics
+    void clear();
+
+    // Retrieve the current metrics as a v8 object
+    v8::Local<v8::Object> get();
+
+    // Increment the counter(s) for a new request;
+    void start_request();
+
+    // Decrement the counter(s) for a new request;
+    void stop_request();
+
+    uint32_t request_count_;
+    uint32_t response_count_;
+    uint32_t pending_request_count_max_;
+    uint32_t response_queue_drain_count_max_;
+    uint32_t response_queue_drain_time_max_;
+};
+
+inline void
+Metrics::clear()
+{
+    request_count_ = 0;
+    response_count_ = 0;
+    pending_request_count_max_ = 0;
+    response_queue_drain_count_max_ = 0;
+    response_queue_drain_time_max_ = 0;
+}
+
+inline void
+Metrics::start_request()
+{
+    request_count_++;
+    uint32_t pending = request_count_ - response_count_;
+    if (pending > pending_request_count_max_) {
+        pending_request_count_max_ = pending;
+    }
+}
+
+inline void
+Metrics::stop_request()
+{
+    response_count_++;
+}
+
+inline v8::Local<v8::Object>
+Metrics::get()
+{
+    NanEscapableScope();
+
+    v8::Local<v8::Object> metrics = NanNew<v8::Object>();
+
+#define GET(x) \
+    static PersistentString x##str(#x); \
+    metrics->Set(x##str, NanNew(x##_));
+
+    GET(request_count);
+    GET(response_count);
+    GET(pending_request_count_max);
+    GET(response_queue_drain_count_max);
+    GET(response_queue_drain_time_max);
+
+#undef GET
+
+    NanReturnValue(metrics);
+}
+
+#endif

--- a/src/prepared-query.h
+++ b/src/prepared-query.h
@@ -11,6 +11,7 @@ using namespace v8;
 
 class AsyncFuture;
 class Client;
+class Metrics;
 
 // Wrapper for an in-progress PreparedQuery to the back end
 class PreparedQuery: public node::ObjectWrap {
@@ -47,6 +48,7 @@ private:
 
     CassSession* session_;
     AsyncFuture* async_;
+    Metrics* metrics_;
     CassStatement* statement_;
     const CassPrepared* prepared_;
 

--- a/src/query.h
+++ b/src/query.h
@@ -11,6 +11,7 @@ using namespace v8;
 
 class AsyncFuture;
 class Client;
+class Metrics;
 
 // Wrapper for an in-progress query to the back end
 class Query: public node::ObjectWrap {
@@ -56,6 +57,7 @@ private:
 
     CassSession* session_;
     CassStatement* statement_;
+    Metrics* metrics_;
 
     bool prepared_;
     bool fetching_;

--- a/test/test-client.js
+++ b/test/test-client.js
@@ -33,6 +33,10 @@ var TestClient = Base.extend({
         return this.client.new_batch(style);
     },
 
+    metrics: function (reset) {
+        return this.client.metrics(reset);
+    },
+
     createKeyspace: function(name, replication) {
         replication = replication || 1;
         this.keyspaces.push(name);


### PR DESCRIPTION
Track and expose statistics from the driver, including the request/response counts, maximum number of pending requests, and maximum number of responses and elapsed time spent in the async-future loop.

Also add an optional guard against spending too much time processing responses, so that if the limit is reached, the loop schedules itself to be woken up again and yields to allow other I/O to take place.
