### PR TITLE
null column values trigger an error

### DIFF
--- a/src/type-mapper.cc
+++ b/src/type-mapper.cc
@@ -52,6 +52,11 @@ bool
 TypeMapper::bind_statement_param(CassStatement* statement, u_int32_t i,
                                 const Local<Value>& value, CassValueType given_type)
 {
+    if (value->IsNull()) {
+        cass_statement_bind_null(statement, i);
+        return true;
+    }
+
     CassValueType type = given_type == CASS_VALUE_TYPE_UNKNOWN ? infer_type(value) : given_type;
     switch(type) {
     case CASS_VALUE_TYPE_BLOB: {
@@ -202,6 +207,12 @@ bool
 TypeMapper::v8_from_cassandra(v8::Local<v8::Value>* result, CassValueType type,
                          const CassValue* value)
 {
+
+    if (value == NULL || cass_value_is_null(value)) {
+        *result = NanNull();
+        return true;
+    }
+
     switch(type) {
     case CASS_VALUE_TYPE_BLOB: {
         const cass_byte_t* data;

--- a/test/null-columns.spec.js
+++ b/test/null-columns.spec.js
@@ -1,0 +1,73 @@
+var TestClient = require('./test-client');
+var Promise = require('bluebird');
+var expect = require('chai').expect;
+var _ = require('underscore');
+var util = require('util');
+var test_utils = require('./test-utils');
+
+describe('columns with null values', function() {
+
+    var ks = 'null_test';
+    var table = 'nulltest';
+    var fields = {
+        'key': 'varchar',
+        'col1': 'int',
+        'col2': 'int',
+        'col3': 'int'
+    };
+
+    var key = 'key';
+    var data = [{
+        'key': 'row-1',
+        'col1': 1,
+
+        // Explicitly pass in `null` for the `col2` column so we can verify that null values can be set
+        'col2': null
+
+        // Do not pass in any value for `col3`
+    }];
+    var client;
+
+    before(function() {
+        client = new TestClient();
+        return test_utils.setup_environment(client)
+            .then(function() {
+                return client.createTable(table, fields, key);
+            })
+            .then(function() {
+                return client.insertRows(table, data);
+            })
+            .catch(function(err) { console.log(err); });
+    });
+
+    it('retrieves null columns', function() {
+        var cql = util.format('SELECT * FROM %s where key = ?', table);
+        return client.prepare(cql)
+            .then(function(prepared) {
+                var q = prepared.query();
+                q.bind(['row-1'], {});
+                Promise.promisifyAll(q);
+                return q.executeAsync({});
+            })
+            .then(function(results) {
+                expect(results.rows.length).equal(1);
+                var row = results.rows[0];
+                console.log(row);
+
+                // All keys should be returned
+                var keys = Object.keys(row);
+                expect(keys.length).equal(4);
+
+                // Verify each column's value
+                expect(row.key).equal('row-1');
+                expect(row.col1).equal(1);
+                expect(row.col2).equal(null);
+                expect(row.col3).equal(null);
+            })
+            .catch(function(err) { console.log(err); });
+    });
+
+    after(function() {
+        return client.cleanup();
+    });
+});


### PR DESCRIPTION
When a row contains a column that is unset or `null` the following error is thrown:
```
unable to obtain column value
```

I poked around a bit in [result.cc](https://github.com/jut-io/node-cassandra-native-driver/blob/master/src/result.cc#L66) and as far as I can work out it seems that the value of a column is used to determine the mapping. Can a rule be added to map null column values to `null` in node land?

Here's a test case that fails on current master
```
var TestClient = require('./test-client');
var Promise = require('bluebird');
var expect = require('chai').expect;
var _ = require('underscore');
var util = require('util');
var test_utils = require('./test-utils');

describe('columns with null values', function() {

    var ks = 'paging_test';
    var table = 'test';
    var fields = {
        'row': 'varchar',
        'col': 'int',
        'val': 'int'
    };

    var key = 'row, col';
    var data = [{
        'row': 'row-1',
        'col': 1
        // Do NOT pass in the val column so it ends up as a null column in Cassandra
    }];
    var client;

    before(function() {
        client = new TestClient();
        return test_utils.setup_environment(client)
            .then(function() {
                return client.createTable(table, fields, key);
            })
            .then(function() {
                return client.insertRows(table, data);
            });
    });

    it('retrieves null columns', function() {
        var cql = util.format('SELECT * FROM %s where ROW = ?', table);
        return client.prepare(cql)
            .then(function(prepared) {
                var q = prepared.query();
                q.bind(['row-1'], {});
                Promise.promisifyAll(q);
                return q.executeAsync({});
            })
            .then(function(results) {
                expect(results.rows.length).equal(1);
                var row = results.rows[0];
                var keys = Object.keys(row);
                expect(keys.length).equal(3);
                expect(row.row).equal('row-1');
                expect(row.col).equal(1);
                expect(row.val).equal(null);
            });
    });

    after(function() {
        return client.cleanup();
    });
});
```