### PR TITLE
Convert timestamp columns into Date objects and vice versa

### DIFF
--- a/src/type-mapper.cc
+++ b/src/type-mapper.cc
@@ -23,6 +23,9 @@ TypeMapper::infer_type(const Local<Value>& value)
     else if (value -> IsBoolean()) {
         return CASS_VALUE_TYPE_BOOLEAN;
     }
+    else if (value->IsDate()) {
+        return CASS_VALUE_TYPE_TIMESTAMP;
+    }
     else if (value -> IsObject()) {
         return CASS_VALUE_TYPE_MAP;
     }
@@ -242,8 +245,15 @@ TypeMapper::v8_from_cassandra(v8::Local<v8::Value>* result, CassValueType type,
         *result = NanNew<Number>(intValue);
         return true;
     }
-    case CASS_VALUE_TYPE_COUNTER:
     case CASS_VALUE_TYPE_TIMESTAMP: {
+        cass_int64_t intValue;
+        if (cass_value_get_int64(value, &intValue) != CASS_OK) {
+            return false;
+        }
+        *result = NanNew<Date>((double)intValue);
+        return true;
+    }
+    case CASS_VALUE_TYPE_COUNTER: {
         cass_int64_t intValue;
         if (cass_value_get_int64(value, &intValue) != CASS_OK) {
             return false;


### PR DESCRIPTION
After the previous PR, I got a taste for it and tried my hand at adding proper timestamp support. Currently it's a bit awkward to deal with timestamp columns. Timestamp values get serialized as numbers, but because timestamps are internally stored as 64 bits the value that's handed to you in JS land is garbage.
You have to resort to passing the timestamp value as a buffer through the `timestampAsBlob` function and then running that through something like [long](https://www.npmjs.com/package/long) to get the actual value back out.

This PR allows you to:
- set columns of type `timestamp` by passing in a `Date` object
- retrieving `timestamp` columns as `Date` objects.

This is a breaking API change as timestamp values are no longer coming back as Numbers but proper Date objects. The PR isn't ready to be merged, but I liked to get your thoughts on whether this is a good idea and worth further development. If you're on board I'll refactor some of those timestamp tests and get this ready to be merged into master
