### PR TITLE
port to use nan 2.1.0 to support newer node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - "0.10"
   - "0.12"
   - "iojs-v2.3.0"
+  - "iojs-v3.0.0"
 before_script:
   - npm install -g grunt-cli node-gyp mocha
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,19 @@
 language: node_js
+env:
+  - CXX="g++-4.8"
 node_js:
   - "0.10"
   - "0.12"
   - "iojs-v2.3.0"
   - "iojs-v3.0.0"
+  - "4"
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - g++-4.8
+    - gcc-4.8
 before_script:
   - npm install -g grunt-cli node-gyp mocha
 services:

--- a/addon.js
+++ b/addon.js
@@ -1,0 +1,6 @@
+if (process.env.CASSANDRA_DRIVER_DEBUG) {
+    console.log('loading debug driver');
+    module.exports = require('./build/Debug/cassandra-native-driver');
+} else {
+    module.exports = require('./build/Release/cassandra-native-driver');
+}

--- a/binding.gyp
+++ b/binding.gyp
@@ -5,6 +5,11 @@
   "targets": [
     {
         "target_name": "cassandra-native-driver",
+
+        "xcode_settings": {
+            "OTHER_CFLAGS": ["-Wno-unused-local-typedefs"]
+        },
+
         "sources": [
         "src/async-future.cc",
         "src/batch.cc",

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var addon = require('./build/Release/cassandra-native-driver');
+var addon = require('./addon');
 
 module.exports = {
     Client: require('./lib/client'),

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,4 +1,4 @@
-var addon = require('../build/Release/cassandra-native-driver');
+var addon = require('../addon');
 
 var debug = require('debug')('cassandra');
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": "https://github.com/jut-io/node-cassandra-native-driver",
   "scripts": {
-    "test": "mocha"
+    "test": "mocha -t 5000"
   },
   "author": "Michael Demmer <demmer@jut.io>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "debug": "^2.1.1",
-    "nan": "^1.8.4"
+    "nan": "^2.1.0"
   },
   "files": [
     "README.md",

--- a/src/batch.cc
+++ b/src/batch.cc
@@ -31,19 +31,16 @@ void Batch::Init() {
 Local<Object> Batch::NewInstance(const Local<String>& type) {
     Nan::EscapableHandleScope scope;
 
-    String::Utf8Value type_str(type);
-
     const unsigned argc = 1;
     Local<Value> argv[argc] = {type};
     Local<Function> cons = Nan::New<Function>(constructor);
-    Local<Object> instance = Nan::NewInstance(cons).ToLocalChecked();
+    Local<Object> instance = Nan::NewInstance(cons, argc, argv).ToLocalChecked();
 
     return scope.Escape(instance);
 }
 
 NAN_METHOD(Batch::New) {
     Nan::EscapableHandleScope scope;
-
     String::Utf8Value type_str(info[0].As<String>());
 
     CassBatchType type;

--- a/src/batch.cc
+++ b/src/batch.cc
@@ -25,24 +25,24 @@ void Batch::Init() {
     Nan::SetPrototypeMethod(tpl, "add_prepared", WRAPPED_METHOD_NAME(AddPrepared));
     Nan::SetPrototypeMethod(tpl, "execute", WRAPPED_METHOD_NAME(Execute));
 
-    Nan::GetFunction(constructor.Reset(tpl));
+    constructor.Reset(tpl->GetFunction());
 }
 
 Local<Object> Batch::NewInstance(const Local<String>& type) {
-    Nan::EscapabpeHandleScope scope;
+    Nan::EscapableHandleScope scope;
 
     String::Utf8Value type_str(type);
 
     const unsigned argc = 1;
     Local<Value> argv[argc] = {type};
     Local<Function> cons = Nan::New<Function>(constructor);
-    Local<Object> instance = Nan::NewInstance(consargc, argv);
+    Local<Object> instance = Nan::NewInstance(cons).ToLocalChecked();
 
     return scope.Escape(instance);
 }
 
 NAN_METHOD(Batch::New) {
-    Nan::EscapabpeHandleScope scope;
+    Nan::EscapableHandleScope scope;
 
     String::Utf8Value type_str(info[0].As<String>());
 
@@ -120,13 +120,13 @@ WRAPPED_METHOD(Batch, AddPrepared)
 
     PreparedQuery* prepared = Nan::ObjectWrap::Unwrap<PreparedQuery>(prepared_obj->ToObject());
     Local<Array> params = info[1].As<Array>();
-    Local<Array> hints;
+    Local<Object> hints;
 
     if (info.Length() > 2) {
         static PersistentString hints_str("hints");
         Local<Object> options = info[2].As<Object>();
-        if Nan::Has((options, hints_str)) {
-            hints = Nan::Get(options, hints_str).As<Array>();
+        if (Nan::Has(options, hints_str).FromJust()) {
+            hints = Nan::To<v8::Object>(Nan::Get(options, hints_str).ToLocalChecked()).ToLocalChecked();
         }
     }
 

--- a/src/batch.cc
+++ b/src/batch.cc
@@ -11,40 +11,40 @@
 #define dprintf(...)
 //#define dprintf printf
 
-Persistent<Function> Batch::constructor;
+Nan::Persistent<Function> Batch::constructor;
 
 void Batch::Init() {
-    NanScope();
+    Nan::Scope scope;
 
     // Prepare constructor template
-    Local<FunctionTemplate> tpl = NanNew<FunctionTemplate>(New);
-    tpl->SetClassName(NanNew("Batch"));
+    Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
+    tpl->SetClassName(Nan::New("Batch").ToLocalChecked());
     tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
-    NODE_SET_PROTOTYPE_METHOD(tpl, "add", WRAPPED_METHOD_NAME(AddQuery));
-    NODE_SET_PROTOTYPE_METHOD(tpl, "add_prepared", WRAPPED_METHOD_NAME(AddPrepared));
-    NODE_SET_PROTOTYPE_METHOD(tpl, "execute", WRAPPED_METHOD_NAME(Execute));
+    Nan::SetPrototypeMethod(tpl, "add", WRAPPED_METHOD_NAME(AddQuery));
+    Nan::SetPrototypeMethod(tpl, "add_prepared", WRAPPED_METHOD_NAME(AddPrepared));
+    Nan::SetPrototypeMethod(tpl, "execute", WRAPPED_METHOD_NAME(Execute));
 
-    NanAssignPersistent(constructor, tpl->GetFunction());
+    Nan::GetFunction(constructor.Reset(tpl));
 }
 
 Local<Object> Batch::NewInstance(const Local<String>& type) {
-    NanEscapableScope();
+    Nan::EscapableScope scope;
 
     String::Utf8Value type_str(type);
 
     const unsigned argc = 1;
     Local<Value> argv[argc] = {type};
-    Local<Function> cons = NanNew<Function>(constructor);
-    Local<Object> instance = cons->NewInstance(argc, argv);
+    Local<Function> cons = Nan::New<Function>(constructor);
+    Local<Object> instance = Nan::NewInstance(consargc, argv);
 
-    return NanEscapeScope(instance);
+    return scope.Escape(instance);
 }
 
 NAN_METHOD(Batch::New) {
-    NanEscapableScope();
+    Nan::EscapableScope scope;
 
-    String::Utf8Value type_str(args[0].As<String>());
+    String::Utf8Value type_str(info[0].As<String>());
 
     CassBatchType type;
     if (!strcasecmp(*type_str, "logged")) {
@@ -57,12 +57,12 @@ NAN_METHOD(Batch::New) {
         type = CASS_BATCH_TYPE_COUNTER;
     }
     else {
-        return NanThrowError("invalid batch type");
+        return Nan::ThrowError("invalid batch type");
     }
     Batch* obj = new Batch(type);
-    obj->Wrap(args.This());
+    obj->Wrap(info.This());
 
-    NanReturnValue(args.This());
+    info.GetReturnValue().Set(info.This());
 }
 
 Batch::Batch(CassBatchType type)
@@ -81,9 +81,9 @@ void
 Batch::set_client(v8::Local<v8::Object> client)
 {
     static PersistentString client_str("client");
-    NanObjectWrapHandle(this)->Set(client_str, client);
+    Nan::Set(this->handle(), client_str, client);
 
-    Client* c = node::ObjectWrap::Unwrap<Client>(client);
+    Client* c = Nan::ObjectWrap::Unwrap<Client>(client);
     session_ = c->get_session();
     async_ = c->get_async();
     metrics_ = c->metrics();
@@ -91,42 +91,42 @@ Batch::set_client(v8::Local<v8::Object> client)
 
 WRAPPED_METHOD(Batch, AddQuery)
 {
-    if (args.Length() != 1) {
-        return NanThrowError("add requires query");
+    if (info.Length() != 1) {
+        return Nan::ThrowError("add requires query");
     }
 
-    Local<Object> query_obj = args[0].As<Object>();
+    Local<Object> query_obj = info[0].As<Object>();
     if (! query_obj->IsObject() || query_obj->InternalFieldCount() == 0) {
-        return NanThrowError("add requires a valid query object");
+        return Nan::ThrowError("add requires a valid query object");
     }
 
-    Query* query = node::ObjectWrap::Unwrap<Query>(query_obj->ToObject());
+    Query* query = Nan::ObjectWrap::Unwrap<Query>(query_obj->ToObject());
 
     cass_batch_add_statement(batch_, query->statement());
 
-    NanReturnUndefined();
+    return;
 }
 
 WRAPPED_METHOD(Batch, AddPrepared)
 {
-    if (args.Length() < 2) {
-        return NanThrowError("add_prepared requires prepared and vals");
+    if (info.Length() < 2) {
+        return Nan::ThrowError("add_prepared requires prepared and vals");
     }
 
-    Local<Object> prepared_obj = args[0].As<Object>();
+    Local<Object> prepared_obj = info[0].As<Object>();
     if (! prepared_obj->IsObject() || prepared_obj->InternalFieldCount() == 0) {
-        return NanThrowError("add_prepared requires a valid prepared object");
+        return Nan::ThrowError("add_prepared requires a valid prepared object");
     }
 
-    PreparedQuery* prepared = node::ObjectWrap::Unwrap<PreparedQuery>(prepared_obj->ToObject());
-    Local<Array> params = args[1].As<Array>();
+    PreparedQuery* prepared = Nan::ObjectWrap::Unwrap<PreparedQuery>(prepared_obj->ToObject());
+    Local<Array> params = info[1].As<Array>();
     Local<Array> hints;
 
-    if (args.Length() > 2) {
+    if (info.Length() > 2) {
         static PersistentString hints_str("hints");
-        Local<Object> options = args[2].As<Object>();
-        if (options->Has(hints_str)) {
-            hints = options->Get(hints_str).As<Array>();
+        Local<Object> options = info[2].As<Object>();
+        if Nan::Has((options, hints_str)) {
+            hints = Nan::Get(options, hints_str).As<Array>();
         }
     }
 
@@ -136,40 +136,40 @@ WRAPPED_METHOD(Batch, AddPrepared)
     if (bindingStatus != -1) {
         char err[1024];
         sprintf(err, "error binding statement argument %d", bindingStatus);
-        return NanThrowError(err);
+        return Nan::ThrowError(err);
     }
 
     cass_batch_add_statement(batch_, statement);
     cass_statement_free(statement);
 
-    NanReturnUndefined();
+    return;
 }
 
 WRAPPED_METHOD(Batch, Execute)
 {
-    NanScope();
+    Nan::Scope scope;
 
-    if (args.Length() != 2) {
-        return NanThrowError("execute requires 2 arguments: options, callback");
+    if (info.Length() != 2) {
+        return Nan::ThrowError("execute requires 2 arguments: options, callback");
     }
 
     if (session_ == NULL) {
-        return NanThrowError("client must be connected");
+        return Nan::ThrowError("client must be connected");
     }
 
     // Guard against running fetch multiple times in parallel
     if (fetching_) {
-        return NanThrowError("fetch already in progress");
+        return Nan::ThrowError("fetch already in progress");
     }
     fetching_ = true;
 
     // Need a reference while the operation is in progress
     Ref();
 
-    Local<Object> options = args[0].As<Object>();
+    Local<Object> options = info[0].As<Object>();
     (void)options; // XXX what options make sense?
 
-    NanCallback* callback = new NanCallback(args[1].As<Function>());
+    Nan::Callback* callback = new Nan::Callback(info[1].As<Function>());
 
     if (result_.result()) {
         cass_result_free(result_.result());
@@ -179,21 +179,21 @@ WRAPPED_METHOD(Batch, Execute)
     metrics_->start_request();
     async_->schedule(on_result_ready, future, this, callback);
 
-    NanReturnUndefined();
+    return;
 }
 
 void
 Batch::on_result_ready(CassFuture* future, void* client, void* data)
 {
     Batch* self = (Batch*)client;
-    NanCallback* callback = (NanCallback*) data;
+    Nan::Callback* callback = (Nan::Callback*) data;
     self->result_ready(future, callback);
 }
 
 void
-Batch::result_ready(CassFuture* future, NanCallback* callback)
+Batch::result_ready(CassFuture* future, Nan::Callback* callback)
 {
-    NanScope();
+    Nan::Scope scope;
 
     metrics_->stop_request();
 

--- a/src/batch.cc
+++ b/src/batch.cc
@@ -14,7 +14,7 @@
 Nan::Persistent<Function> Batch::constructor;
 
 void Batch::Init() {
-    Nan::Scope scope;
+    Nan::HandleScope scope;
 
     // Prepare constructor template
     Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
@@ -29,7 +29,7 @@ void Batch::Init() {
 }
 
 Local<Object> Batch::NewInstance(const Local<String>& type) {
-    Nan::EscapableScope scope;
+    Nan::EscapabpeHandleScope scope;
 
     String::Utf8Value type_str(type);
 
@@ -42,7 +42,7 @@ Local<Object> Batch::NewInstance(const Local<String>& type) {
 }
 
 NAN_METHOD(Batch::New) {
-    Nan::EscapableScope scope;
+    Nan::EscapabpeHandleScope scope;
 
     String::Utf8Value type_str(info[0].As<String>());
 
@@ -147,7 +147,7 @@ WRAPPED_METHOD(Batch, AddPrepared)
 
 WRAPPED_METHOD(Batch, Execute)
 {
-    Nan::Scope scope;
+    Nan::HandleScope scope;
 
     if (info.Length() != 2) {
         return Nan::ThrowError("execute requires 2 arguments: options, callback");
@@ -193,7 +193,7 @@ Batch::on_result_ready(CassFuture* future, void* client, void* data)
 void
 Batch::result_ready(CassFuture* future, Nan::Callback* callback)
 {
-    Nan::Scope scope;
+    Nan::HandleScope scope;
 
     metrics_->stop_request();
 

--- a/src/batch.cc
+++ b/src/batch.cc
@@ -34,7 +34,9 @@ Local<Object> Batch::NewInstance(const Local<String>& type) {
     const unsigned argc = 1;
     Local<Value> argv[argc] = {type};
     Local<Function> cons = Nan::New<Function>(constructor);
-    Local<Object> instance = Nan::NewInstance(cons, argc, argv).ToLocalChecked();
+//    Local<Object> instance = Nan::NewInstance(cons, argc, argv).ToLocalChecked();
+
+    Local<Object> instance = cons->NewInstance(argc, argv);
 
     return scope.Escape(instance);
 }

--- a/src/batch.h
+++ b/src/batch.h
@@ -14,7 +14,7 @@ class Client;
 class Metrics;
 
 // Wrapper for a batched query
-class Batch: public node::ObjectWrap {
+class Batch: public Nan::ObjectWrap {
 public:
     // Initialize the class constructor.
     static void Init();
@@ -43,7 +43,7 @@ private:
     WRAPPED_METHOD_DECL(Execute);
 
     static void on_result_ready(CassFuture* future, void* client, void* data);
-    void result_ready(CassFuture* future, NanCallback* callback);
+    void result_ready(CassFuture* future, Nan::Callback* callback);
 
     CassSession* session_;
     CassBatch* batch_;
@@ -54,7 +54,7 @@ private:
     AsyncFuture* async_;
     Result result_;
 
-    static v8::Persistent<v8::Function> constructor;
+    static Nan::Persistent<v8::Function> constructor;
 };
 
 #endif

--- a/src/cassandra-driver.cc
+++ b/src/cassandra-driver.cc
@@ -12,24 +12,23 @@
 using namespace v8;
 
 NAN_METHOD(CreateClient) {
-    NanScope();
-    NanReturnValue(Client::NewInstance(args[0]));
+    info.GetReturnValue().Set(Client::NewInstance(info[0]));
 }
 
 void InitAll(Handle<Object> exports) {
-    NanScope();
+    Nan::Scope scope;
 
     Batch::Init();
     Client::Init();
     PreparedQuery::Init();
     Query::Init();
 
-    exports->Set(NanNew("Client"),
-        NanNew<FunctionTemplate>(CreateClient)->GetFunction());
-    exports->Set(NanNew("set_log_callback"),
-        NanNew<FunctionTemplate>(SetLogCallback)->GetFunction());
-    exports->Set(NanNew("set_log_level"),
-        NanNew<FunctionTemplate>(SetLogLevel)->GetFunction());
+    Nan::Set(exports, Nan::New("Client").ToLocalChecked(),
+        Nan::GetFunction(Nan::New<FunctionTemplate>(CreateClient)));
+    Nan::Set(exports, Nan::New("set_log_callback").ToLocalChecked(),
+        Nan::GetFunction(Nan::New<FunctionTemplate>(SetLogCallback)));
+    Nan::Set(exports, Nan::New("set_log_level").ToLocalChecked(),
+        Nan::GetFunction(Nan::New<FunctionTemplate>(SetLogLevel)));
 }
 
 NODE_MODULE(cassandra_native_driver, InitAll)

--- a/src/cassandra-driver.cc
+++ b/src/cassandra-driver.cc
@@ -24,11 +24,11 @@ void InitAll(Handle<Object> exports) {
     Query::Init();
 
     Nan::Set(exports, Nan::New("Client").ToLocalChecked(),
-        Nan::GetFunction(Nan::New<FunctionTemplate>(CreateClient)));
+        Nan::GetFunction(Nan::New<FunctionTemplate>(CreateClient)).ToLocalChecked());
     Nan::Set(exports, Nan::New("set_log_callback").ToLocalChecked(),
-        Nan::GetFunction(Nan::New<FunctionTemplate>(SetLogCallback)));
+        Nan::GetFunction(Nan::New<FunctionTemplate>(SetLogCallback)).ToLocalChecked());
     Nan::Set(exports, Nan::New("set_log_level").ToLocalChecked(),
-        Nan::GetFunction(Nan::New<FunctionTemplate>(SetLogLevel)));
+        Nan::GetFunction(Nan::New<FunctionTemplate>(SetLogLevel)).ToLocalChecked());
 }
 
 NODE_MODULE(cassandra_native_driver, InitAll)

--- a/src/cassandra-driver.cc
+++ b/src/cassandra-driver.cc
@@ -16,7 +16,7 @@ NAN_METHOD(CreateClient) {
 }
 
 void InitAll(Handle<Object> exports) {
-    Nan::Scope scope;
+    Nan::HandleScope scope;
 
     Batch::Init();
     Client::Init();

--- a/src/client.cc
+++ b/src/client.cc
@@ -49,7 +49,7 @@ Local<Object> Client::NewInstance(Local<Value> arg) {
     const unsigned argc = 1;
     Local<Value> argv[argc] = { arg };
     Local<Function> cons = Nan::New<Function>(constructor);
-    Local<Object> instance = Nan::NewInstance(cons).ToLocalChecked();
+    Local<Object> instance = Nan::NewInstance(cons, argc, argv).ToLocalChecked();
 
     return scope.Escape(instance);
 }

--- a/src/client.cc
+++ b/src/client.cc
@@ -49,7 +49,8 @@ Local<Object> Client::NewInstance(Local<Value> arg) {
     const unsigned argc = 1;
     Local<Value> argv[argc] = { arg };
     Local<Function> cons = Nan::New<Function>(constructor);
-    Local<Object> instance = Nan::NewInstance(cons, argc, argv).ToLocalChecked();
+//    Local<Object> instance = Nan::NewInstance(cons, argc, argv).ToLocalChecked();
+    Local<Object> instance = cons->NewInstance(argc, argv);
 
     return scope.Escape(instance);
 }

--- a/src/client.cc
+++ b/src/client.cc
@@ -25,7 +25,7 @@ Client::~Client() {
 }
 
 void Client::Init() {
-    Nan::Scope scope;
+    Nan::HandleScope scope;
 
     // Prepare constructor template
     Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
@@ -43,7 +43,7 @@ void Client::Init() {
 }
 
 Local<Object> Client::NewInstance(Local<Value> arg) {
-    Nan::EscapableScope scope;
+    Nan::EscapabpeHandleScope scope;
 
     const unsigned argc = 1;
     Local<Value> argv[argc] = { arg };
@@ -124,7 +124,7 @@ Client::configure(v8::Local<v8::Object> opts)
 }
 
 WRAPPED_METHOD(Client, Connect) {
-    Nan::Scope scope;
+    Nan::HandleScope scope;
 
     if (info.Length() != 2) {
         return Nan::ThrowError("connect requires 2 arguments: options and callback");
@@ -168,7 +168,7 @@ Client::on_connected(CassFuture* future, void* client, void* data)
 void
 Client::connected(CassFuture* future, Nan::Callback* callback)
 {
-    Nan::Scope scope;
+    Nan::HandleScope scope;
 
     CassError code = cass_future_error_code(future);
     if (code != CASS_OK) {
@@ -186,7 +186,7 @@ Client::connected(CassFuture* future, Nan::Callback* callback)
 }
 
 WRAPPED_METHOD(Client, NewQuery) {
-    Nan::Scope scope;
+    Nan::HandleScope scope;
     Local<Value> val = Query::NewInstance();
 
     Query* query = Nan::ObjectWrap::Unwrap<Query>(val->ToObject());
@@ -196,7 +196,7 @@ WRAPPED_METHOD(Client, NewQuery) {
 }
 
 WRAPPED_METHOD(Client, NewPreparedQuery) {
-    Nan::Scope scope;
+    Nan::HandleScope scope;
     Local<Value> val = PreparedQuery::NewInstance();
 
     PreparedQuery* query = Nan::ObjectWrap::Unwrap<PreparedQuery>(val->ToObject());
@@ -206,7 +206,7 @@ WRAPPED_METHOD(Client, NewPreparedQuery) {
 }
 
 WRAPPED_METHOD(Client, NewBatch) {
-    Nan::Scope scope;
+    Nan::HandleScope scope;
 
     if (info.Length() != 1) {
         return Nan::ThrowError("must specify batch type");
@@ -223,7 +223,7 @@ WRAPPED_METHOD(Client, NewBatch) {
 }
 
 WRAPPED_METHOD(Client, GetMetrics) {
-    Nan::Scope scope;
+    Nan::HandleScope scope;
 
     bool reset = false;
     if (info.Length() == 1) {

--- a/src/client.cc
+++ b/src/client.cc
@@ -175,7 +175,7 @@ Client::connected(CassFuture* future, Nan::Callback* callback)
     if (code != CASS_OK) {
         error_callback(future, callback);
     } else {
-        Handle<Value> argv[] = {
+        Local<Value> argv[] = {
             Nan::Null(),
         };
         callback->Call(1, argv);

--- a/src/client.h
+++ b/src/client.h
@@ -8,7 +8,7 @@
 #include "async-future.h"
 #include "metrics.h"
 
-class Client : public node::ObjectWrap {
+class Client : public Nan::ObjectWrap {
 public:
     static void Init();
     static v8::Local<v8::Object> NewInstance(v8::Local<v8::Value> arg);
@@ -24,7 +24,7 @@ private:
     AsyncFuture async_;
 
     static void on_connected(CassFuture* future, void* client, void* data);
-    void connected(CassFuture* future, NanCallback* callback);
+    void connected(CassFuture* future, Nan::Callback* callback);
 
     explicit Client();
     ~Client();
@@ -39,7 +39,7 @@ private:
 
     void configure(v8::Local<v8::Object> opts);
 
-    static v8::Persistent<v8::Function> constructor;
+    static Nan::Persistent<v8::Function> constructor;
 };
 
 #endif

--- a/src/error-callback.h
+++ b/src/error-callback.h
@@ -5,9 +5,9 @@
  * Call the given callback with a new error wrapping the msg extracted
  * from the given future.
  */
-inline void error_callback(CassFuture* future, NanCallback* callback)
+inline void error_callback(CassFuture* future, Nan::Callback* callback)
 {
-    NanScope();
+    Nan::Scope scope;
 
     const char* msg;
     size_t msg_len;
@@ -16,7 +16,7 @@ inline void error_callback(CassFuture* future, NanCallback* callback)
     std::string err(msg, msg_len);
 
     Handle<Value> argv[] = {
-        NanError(err.c_str())
+        Nan::Error(err.c_str())
     };
 
     callback->Call(1, argv);

--- a/src/error-callback.h
+++ b/src/error-callback.h
@@ -15,7 +15,7 @@ inline void error_callback(CassFuture* future, Nan::Callback* callback)
 
     std::string err(msg, msg_len);
 
-    Handle<Value> argv[] = {
+    Local<Value> argv[] = {
         Nan::Error(err.c_str())
     };
 

--- a/src/error-callback.h
+++ b/src/error-callback.h
@@ -7,7 +7,7 @@
  */
 inline void error_callback(CassFuture* future, Nan::Callback* callback)
 {
-    Nan::Scope scope;
+    Nan::HandleScope scope;
 
     const char* msg;
     size_t msg_len;

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -73,8 +73,6 @@ NAN_METHOD(SetLogCallback) {
     uv_async_init(uv_default_loop(), async_, async_ready);
 
     cass_log_set_callback(on_log_message, NULL);
-
-    NanReturnNull();
 }
 
 NAN_METHOD(SetLogLevel) {
@@ -102,6 +100,4 @@ NAN_METHOD(SetLogLevel) {
     }
 
     cass_log_set_level(level);
-
-    NanReturnNull();
 }

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -38,7 +38,7 @@ async_ready(uv_async_t* handle)
         static PersistentString message("message");
 
         Nan::Set(info, time_ms.handle(), Nan::New<Number>(log->time_ms));
-        Nan::Set(info, severity.handle(), Nan::New<String>(cass_log_level_string(log->severity).ToLocalChecked()));
+        Nan::Set(info, severity.handle(), Nan::New<String>(cass_log_level_string(log->severity)).ToLocalChecked());
         Nan::Set(info, message.handle(), Nan::New<String>(log->message).ToLocalChecked());
 
         Handle<Value> argv[] = {

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -26,7 +26,7 @@ async_ready(uv_async_t* handle, int status)
 async_ready(uv_async_t* handle)
 #endif
 {
-    Nan::Scope scope;
+    Nan::HandleScope scope;
     uv_mutex_lock(&lock_);
 
     for (size_t i = 0; i < queue_.size(); i++) {

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -41,7 +41,7 @@ async_ready(uv_async_t* handle)
         Nan::Set(info, severity.handle(), Nan::New<String>(cass_log_level_string(log->severity)).ToLocalChecked());
         Nan::Set(info, message.handle(), Nan::New<String>(log->message).ToLocalChecked());
 
-        Handle<Value> argv[] = {
+        Local<Value> argv[] = {
             Nan::Null(),
             info
         };

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -58,7 +58,7 @@ Metrics::get(v8::Local<v8::Object> metrics)
 {
 #define GET(x) \
     static PersistentString x##str(#x); \
-    metrics->Set(x##str, NanNew(x##_));
+    Nan::Set(metrics, x##str, Nan::New(x##_));
 
     GET(request_count);
     GET(response_count);

--- a/src/persistent-string.h
+++ b/src/persistent-string.h
@@ -6,15 +6,18 @@
 // Simple helper class
 class PersistentString {
 public:
+    typedef Nan::Persistent<v8::String> PersistentStringRef;
+    
     PersistentString(const char* str) : string_(str) {
     }
 
     // Return a local handle to the persistent string
     v8::Local<v8::String> handle() {
         if (handle_.IsEmpty()) {
-            NanAssignPersistent(handle_, NanNew<v8::String>(string_.c_str()));
+            v8::Local<v8::String> local = Nan::New<v8::String>(string_).ToLocalChecked();
+            handle_.Reset(local);
         }
-        return NanNew<v8::String>(handle_);
+        return Nan::New<v8::String>(handle_);
     }
 
     // Define the casting operator to a local handle so that a persistent string
@@ -28,7 +31,7 @@ public:
     }
 
 private:
-    v8::Persistent<v8::String> handle_;
+    PersistentStringRef handle_;
     std::string string_;
 };
 

--- a/src/prepared-query.cc
+++ b/src/prepared-query.cc
@@ -113,7 +113,7 @@ PreparedQuery::prepared_ready(CassFuture* future, Nan::Callback* callback)
     } else {
         prepared_ = cass_future_get_prepared(future);
 
-        Handle<Value> argv[] = {
+        Local<Value> argv[] = {
             Nan::Null(),
             this->handle()
         };

--- a/src/prepared-query.cc
+++ b/src/prepared-query.cc
@@ -30,7 +30,8 @@ Local<Object> PreparedQuery::NewInstance() {
     const unsigned argc = 0;
     Local<Value> argv[argc] = {};
     Local<Function> cons = Nan::New<Function>(constructor);
-    Local<Object> instance = Nan::NewInstance(cons, argc, argv).ToLocalChecked();
+//    Local<Object> instance = Nan::NewInstance(cons, argc, argv).ToLocalChecked();
+    Local<Object> instance = cons->NewInstance(argc, argv);
 
     return scope.Escape(instance);
 }

--- a/src/prepared-query.cc
+++ b/src/prepared-query.cc
@@ -30,7 +30,7 @@ Local<Object> PreparedQuery::NewInstance() {
     const unsigned argc = 0;
     Local<Value> argv[argc] = {};
     Local<Function> cons = Nan::New<Function>(constructor);
-    Local<Object> instance = Nan::NewInstance(cons).ToLocalChecked();
+    Local<Object> instance = Nan::NewInstance(cons, argc, argv).ToLocalChecked();
 
     return scope.Escape(instance);
 }

--- a/src/prepared-query.h
+++ b/src/prepared-query.h
@@ -13,7 +13,7 @@ class Client;
 class Metrics;
 
 // Wrapper for an in-progress PreparedQuery to the back end
-class PreparedQuery: public node::ObjectWrap {
+class PreparedQuery: public Nan::ObjectWrap {
 public:
     // Initialize the class constructor.
     static void Init();
@@ -43,7 +43,7 @@ private:
     WRAPPED_METHOD_DECL(GetQuery);
 
     static void on_prepared_ready(CassFuture* future, void* client, void* data);
-    void prepared_ready(CassFuture* future, NanCallback* callback);
+    void prepared_ready(CassFuture* future, Nan::Callback* callback);
 
     CassSession* session_;
     AsyncFuture* async_;
@@ -51,7 +51,7 @@ private:
     CassStatement* statement_;
     const CassPrepared* prepared_;
 
-    static v8::Persistent<v8::Function> constructor;
+    static Nan::Persistent<v8::Function> constructor;
 };
 
 #endif

--- a/src/query.cc
+++ b/src/query.cc
@@ -12,7 +12,7 @@
 Nan::Persistent<Function> Query::constructor;
 
 void Query::Init() {
-    Nan::Scope scope;
+    Nan::HandleScope scope;
 
     // Prepare constructor template
     Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
@@ -27,7 +27,7 @@ void Query::Init() {
 }
 
 Local<Object> Query::NewInstance() {
-    Nan::EscapableScope scope;
+    Nan::EscapabpeHandleScope scope;
 
     const unsigned argc = 0;
     Local<Value> argv[argc] = {};
@@ -38,7 +38,7 @@ Local<Object> Query::NewInstance() {
 }
 
 NAN_METHOD(Query::New) {
-    Nan::EscapableScope scope;
+    Nan::EscapabpeHandleScope scope;
 
     Query* obj = new Query();
     obj->Wrap(info.This());
@@ -92,7 +92,7 @@ Query::set_prepared_statement(CassStatement* statement)
 
 WRAPPED_METHOD(Query, Parse)
 {
-    Nan::Scope scope;
+    Nan::HandleScope scope;
 
     if (info.Length() < 1) {
         return Nan::ThrowError("invalid arguments");
@@ -160,7 +160,7 @@ Query::bind(Local<Array>& params, Local<Object>& options)
 
 WRAPPED_METHOD(Query, Execute)
 {
-    Nan::Scope scope;
+    Nan::HandleScope scope;
 
     if (info.Length() != 2) {
         return Nan::ThrowError("execute requires 2 arguments: options, callback");
@@ -216,7 +216,7 @@ Query::on_result_ready(CassFuture* future, void* client, void* data)
 void
 Query::result_ready(CassFuture* future, Nan::Callback* callback)
 {
-    Nan::Scope scope;
+    Nan::HandleScope scope;
 
     metrics_->stop_request();
 

--- a/src/query.cc
+++ b/src/query.cc
@@ -138,7 +138,7 @@ WRAPPED_METHOD(Query, Bind)
     return bind(params, options);
 }
 
-NAN_METHOD_RETURN_TYPE
+Nan::NAN_METHOD_RETURN_TYPE
 Query::bind(Local<Array>& params, Local<Object>& options)
 {
     static PersistentString hints_str("hints");

--- a/src/query.cc
+++ b/src/query.cc
@@ -33,7 +33,7 @@ Local<Object> Query::NewInstance() {
     const unsigned argc = 0;
     Local<Value> argv[argc] = {};
     Local<Function> cons = Nan::New<Function>(constructor);
-    Local<Object> instance = Nan::NewInstance(cons).ToLocalChecked();
+    Local<Object> instance = Nan::NewInstance(cons, argc, argv).ToLocalChecked();
 
     return scope.Escape(instance);
 }

--- a/src/query.cc
+++ b/src/query.cc
@@ -33,7 +33,8 @@ Local<Object> Query::NewInstance() {
     const unsigned argc = 0;
     Local<Value> argv[argc] = {};
     Local<Function> cons = Nan::New<Function>(constructor);
-    Local<Object> instance = Nan::NewInstance(cons, argc, argv).ToLocalChecked();
+//    Local<Object> instance = Nan::NewInstance(cons, argc, argv).ToLocalChecked();
+    Local<Object> instance = cons->NewInstance(argc, argv);
 
     return scope.Escape(instance);
 }

--- a/src/query.h
+++ b/src/query.h
@@ -50,7 +50,7 @@ private:
     // Execute the query, potentially retrieving additional pages.
     WRAPPED_METHOD_DECL(Execute);
 
-    NAN_METHOD_RETURN_TYPE bind(Local<Array>& params, Local<Object>& options);
+    Nan::NAN_METHOD_RETURN_TYPE bind(Local<Array>& params, Local<Object>& options);
 
     static void on_result_ready(CassFuture* future, void* client, void* data);
     void result_ready(CassFuture* future, Nan::Callback* callback);

--- a/src/query.h
+++ b/src/query.h
@@ -14,7 +14,7 @@ class Client;
 class Metrics;
 
 // Wrapper for an in-progress query to the back end
-class Query: public node::ObjectWrap {
+class Query: public Nan::ObjectWrap {
 public:
     // Initialize the class constructor.
     static void Init();
@@ -50,10 +50,10 @@ private:
     // Execute the query, potentially retrieving additional pages.
     WRAPPED_METHOD_DECL(Execute);
 
-    _NAN_METHOD_RETURN_TYPE bind(Local<Array>& params, Local<Object>& options);
+    NAN_METHOD_RETURN_TYPE bind(Local<Array>& params, Local<Object>& options);
 
     static void on_result_ready(CassFuture* future, void* client, void* data);
-    void result_ready(CassFuture* future, NanCallback* callback);
+    void result_ready(CassFuture* future, Nan::Callback* callback);
 
     CassSession* session_;
     CassStatement* statement_;
@@ -65,7 +65,7 @@ private:
     AsyncFuture* async_;
     Result result_;
 
-    static v8::Persistent<v8::Function> constructor;
+    static Nan::Persistent<v8::Function> constructor;
 };
 
 #endif

--- a/src/result.cc
+++ b/src/result.cc
@@ -26,7 +26,7 @@ Result::~Result()
 void
 Result::do_callback(CassFuture* future, Nan::Callback* callback)
 {
-    Nan::Scope scope;
+    Nan::HandleScope scope;
 
     CassError code = cass_future_error_code(future);
     if (code != CASS_OK) {

--- a/src/result.cc
+++ b/src/result.cc
@@ -74,7 +74,7 @@ Result::do_callback(CassFuture* future, Nan::Callback* callback)
             {
                 // XXX temporary until all the types are implemented in
                 // TypeMapper.
-                Handle<Value> argv[] = {
+                Local<Value> argv[] = {
                     Nan::Error("unable to obtain column value")
                 };
                 callback->Call(1, argv);
@@ -87,7 +87,7 @@ Result::do_callback(CassFuture* future, Nan::Callback* callback)
     }
     cass_iterator_free(iterator);
 
-    Handle<Value> argv[] = {
+    Local<Value> argv[] = {
         Nan::Null(),
         res
     };

--- a/src/result.h
+++ b/src/result.h
@@ -15,17 +15,17 @@ public:
 
     const CassResult* result() { return result_; }
 
-    void do_callback(CassFuture* future, NanCallback* callback);
+    void do_callback(CassFuture* future, Nan::Callback* callback);
 private:
     // Encapsulation of column metadata that can be cached for each row in the
     // results.
     struct Column {
         Column(const char* name, size_t name_length, CassValueType type) {
-            NanAssignPersistent(name_, NanNew<v8::String>(name, name_length));
+            name_.Reset(Nan::New<v8::String>(name, name_length).ToLocalChecked());
             type_ = type;
         };
 
-        v8::Persistent<v8::String> name_;
+        Nan::Persistent<v8::String> name_;
         CassValueType type_;
     };
     typedef std::vector<Column*> ColumnInfo;

--- a/src/type-mapper.cc
+++ b/src/type-mapper.cc
@@ -231,7 +231,7 @@ TypeMapper::v8_from_cassandra(v8::Local<v8::Value>* result, CassValueType type,
         if (cass_value_get_bytes(value, &data, &size) != CASS_OK) {
             return false;
         }
-        *result = Nan::NewBuffer((char*)data, size).ToLocalChecked();
+        *result = Nan::CopyBuffer((char*)data, size).ToLocalChecked();
         return true;
     }
     case CASS_VALUE_TYPE_ASCII:

--- a/src/type-mapper.cc
+++ b/src/type-mapper.cc
@@ -130,8 +130,8 @@ TypeMapper::bind_statement_param(CassStatement* statement, u_int32_t i,
     case CASS_VALUE_TYPE_BIGINT: {
         // Bigints are passed in as {'low': <lowInt>, 'high': <highInt>}
         Local<Object> obj = value->ToObject();
-        Local<Value> lowKey = NanNew<String>("low", 3);
-        Local<Value> highKey = NanNew<String>("high", 4);
+        Local<String> lowKey = Nan::New<String>("low").ToLocalChecked();
+        Local<String> highKey = Nan::New<String>("high").ToLocalChecked();
         int lowVal = obj->Get(lowKey)->ToNumber()->NumberValue();
         int highVal = obj->Get(highKey)->ToNumber()->NumberValue();
 
@@ -220,7 +220,7 @@ TypeMapper::v8_from_cassandra(v8::Local<v8::Value>* result, CassValueType type,
 {
 
     if (value == NULL || cass_value_is_null(value)) {
-        *result = NanNull();
+        *result = Nan::Null();
         return true;
     }
 
@@ -321,11 +321,11 @@ TypeMapper::v8_from_cassandra(v8::Local<v8::Value>* result, CassValueType type,
         //         "low": <lowValue>,
         //         "high": <highValue>
         //     }
-        Local<Value> lowKey = NanNew<String>("low");
-        Local<Value> highKey = NanNew<String>("high");
-        Local<Value> lowVal = NanNew<Number>((double)low);
-        Local<Value> highVal = NanNew<Number>((double)high);
-        Local<Object> obj = NanNew<Object>();
+        Local<String> lowKey = Nan::New<String>("low").ToLocalChecked();
+        Local<String> highKey = Nan::New<String>("high").ToLocalChecked();
+        Local<Number> lowVal = Nan::New<Number>((double)low);
+        Local<Number> highVal = Nan::New<Number>((double)high);
+        Local<Object> obj = Nan::New<Object>();
         obj->Set(lowKey, lowVal);
         obj->Set(highKey, highVal);
         *result = obj;

--- a/src/type-mapper.h
+++ b/src/type-mapper.h
@@ -12,7 +12,7 @@ public:
     // Bind each element of params to statement, using hints if given to infer types
     // if one of the bindings fails, return the index of that element
     // or -1 if successful
-    static int bind_statement_params(CassStatement* statement, v8::Local<v8::Array> params, v8::Local<v8::Array> hints);
+    static int bind_statement_params(CassStatement* statement, v8::Local<v8::Array> params, v8::Local<v8::Object> hints);
 
     // Set the given Javascript value as the i'th parameter to the statement
     static bool bind_statement_param(CassStatement* statement, u_int32_t i,

--- a/src/wrapped-method.h
+++ b/src/wrapped-method.h
@@ -9,8 +9,8 @@
 
 #define WRAPPED_METHOD(_cls, _name) \
     NAN_METHOD(_cls::WRAPPED_METHOD_NAME(_name)) { \
-        _cls* obj = ObjectWrap::Unwrap<_cls>(args.Holder()); \
-        return obj->_name(args); \
+        _cls* obj = Nan::ObjectWrap::Unwrap<_cls>(info.Holder()); \
+        return obj->_name(info); \
     } \
     NAN_METHOD(_cls::_name)
 

--- a/test/connect-errors.spec.js
+++ b/test/connect-errors.spec.js
@@ -15,7 +15,7 @@ describe('connection error handling', function() {
             .catch(function(err) {
                 expect(err.message).equal('No hosts available for the control connection');
             })
-            .delay(10);
+            .delay(25);
         });
     });
 });

--- a/test/logging.spec.js
+++ b/test/logging.spec.js
@@ -16,8 +16,7 @@ describe('log callback', function() {
     }
 
     it('enables callback to obtain log messages', function() {
-        var ret = cassandra.set_log_callback(log_callback);
-        expect(ret).is.null;
+        cassandra.set_log_callback(log_callback);
 
         var c = new cassandra.Client();
         return c.connectAsync({address: '127.0.0.1', port: 9999})
@@ -38,8 +37,7 @@ describe('log callback', function() {
     });
 
     it('supports configurable log level', function() {
-        var ret = cassandra.set_log_level("TRACE");
-        expect(ret).is.null;
+        cassandra.set_log_level("TRACE");
 
         var c = new cassandra.Client();
         return c.connectAsync({address: '127.0.0.1', port: 9999})

--- a/test/timestamp.spec.js
+++ b/test/timestamp.spec.js
@@ -30,7 +30,7 @@ describe('timestamp support', function() {
         describe(method, function() {
             it('inserts data with timestamp', function() {
                 var now = new Date().getTime();
-                return client[method](table, data, {timestamp: now, ttl: 1});
+                return client[method](table, data, {timestamp: now, ttl: 2});
             });
 
             it('retrieves all the data when immediately querying', function() {
@@ -53,7 +53,7 @@ describe('timestamp support', function() {
 
             it('waits for a few seconds', function() {
                 this.timeout(5000);
-                return Promise.delay(2000);
+                return Promise.delay(4000);
             });
 
             it('queries again and should get no data', function() {


### PR DESCRIPTION
Add support for newer versions of node / iojs by porting to nan version 2.1.0.

The Nan API was pretty much fully rewritten as of 2.0, so there are a lot of formulaic boilerplate changes here.
